### PR TITLE
Some more fixes for Ularn

### DIFF
--- a/src/data.c
+++ b/src/data.c
@@ -21,10 +21,10 @@ char larnlevels[MAXPATHLEN];
 char fortfile[MAXPATHLEN];
 
 /* the options file filename */
-char optsfile[MAXPATHLEN] =".Ularnopts";
+char optsfile[MAXPATHLEN];
 
 /* the checkpoint file filename */
-char ckpfile[MAXPATHLEN] ="Ularn.ckp";
+char ckpfile[MAXPATHLEN];
 
 /* the diagnostic filename	*/
 char diagfile[] ="Diagfile";		

--- a/src/main.c
+++ b/src/main.c
@@ -44,7 +44,6 @@ int argc;
 char *argv[];
 {
 	int i, hard;
-	char buf[BUFSIZ];
 	char *getenv(), *getlogin(), *ptr=0;
 	struct passwd *pwe,*getpwuid();
 	extern char *optarg;
@@ -90,11 +89,9 @@ noone:		    	fprintf(stderr,"Who *are* you?\n");
 	/* save file name in home directory */
 	sprintf(savefilename, "%s/Ularn.sav", ptr);
 
-	sprintf(buf, "%s/%s",ptr, optsfile); 	/* the .Ularnopts filename */
-	strcpy(optsfile, buf);
+	sprintf(optsfile, "%s/.Ularnopts", ptr); 	/* the .Ularnopts filename */
 
-	sprintf(buf, "%s/%s", ptr, ckpfile);	/* the checkpoint file */
-	strcpy(ckpfile, buf);
+	sprintf(ckpfile, "%s/Ularn.ckp", ptr);		/* the checkpoint file */
 
 	sprintf(scorefile, "%s/%s", libdir, SCORENAME); /* the Ularn scoreboard filename */
 

--- a/src/savelev.c
+++ b/src/savelev.c
@@ -187,6 +187,9 @@ int savegame(char *fname)
 	bwrite(save_data,(char *)&FileSum, sizeof(FileSum));
 	flush_buffer(fname, save_data);
 
+	free(save_data->data);
+	free(save_data);
+
 	nosignal = 0;
 	if (do_fork)
 		exit(0);

--- a/src/savelev.c
+++ b/src/savelev.c
@@ -57,6 +57,7 @@ void savelevel()
 {
 	Saved_Level *storage = saved_levels[level];
 
+	memset(storage, 0, sizeof(Saved_Level));
 	memcpy((char *)storage->hitp,  (char *)hitp,  sizeof(Short_Ary));
 	memcpy((char *)storage->mitem, (char *)mitem, sizeof(Mitem_Ary));
 	memcpy((char *)storage->item,  (char *)item,  sizeof(Char_Ary));


### PR DESCRIPTION
While trying to get Ularn running on a small, embedded system, I discovered some more minor issues: A memory leak, a problem reported by Valgrind about Ularn using uninitalized memory, and a possibility to save some memory on the stack in the main() function.